### PR TITLE
remove bootstrap-glyphicons.css reference

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -46,7 +46,6 @@
         <link rel="stylesheet" href="{{ SITEURL }}/theme/css/bootstrap.min.css" type="text/css"/>
     {% endif %}
     <link href="{{ SITEURL }}/theme/css/font-awesome.min.css" rel="stylesheet">
-    <link href="{{ SITEURL }}/theme/css/bootstrap-glyphicons.css" rel="stylesheet">
     <link href="{{ SITEURL }}/theme/css/pygments.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/style.css" type="text/css"/>
     <!-- JavaScript plugins (requires jQuery) -->


### PR DESCRIPTION
Removed a reference to a file that was deleted via d185ccf9b4a84a67d674aeabf90d7666add40779.
