### PR TITLE
strip html tags from an article title where needed

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ article.title }}{% endblock %}
+{% block title %}{{ article.title|striptags }}{% endblock %}
 {% block content %}
     <section id="content">
         <article>
@@ -7,7 +7,7 @@
                 <h1>
                     <a href="{{ SITEURL }}/{{ article.url }}"
                        rel="bookmark"
-                       title="Permalink to {{ article.title }}">
+                       title="Permalink to {{ article.title|striptags }}">
                         {{ article.title }}
                     </a>
                 </h1>

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
         {% endif %}
         {% if article %}
             <meta property="og:type" content="article"/>
-            <meta property="og:title" content="{{ article.title }}"/>
+            <meta property="og:title" content="{{ article.title|striptags }}"/>
             <meta property="og:url" content="{{ SITEURL }}/{{ article.url }}"/>
             <meta property="og:description" content="{{ article.summary|striptags }}"/>
         {% elif page %}


### PR DESCRIPTION
- striptags from title section
- striptags from meta og:title
- striptags from anchor title attribute

This will allow for font awesome icons to be placed in article titles and will fix #4
