### PR TITLE
use archives URL from settings

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -96,7 +96,7 @@
                 {% endif %}
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="{{ SITEURL }}/archives.html"><i class="icon-th-list"></i>Archives</a></li>
+                <li><a href="{{ SITEURL }}/{{ ARCHIVES_URL | default('archives.html') }}"><i class="icon-th-list"></i>Archives</a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->


### PR DESCRIPTION
I use `/archives/` instead of `/archives.html` for my archives path.  This patch uses the config parameter `ARCHIVES_URL`, which seems like a good compromise.

If the project doesn't have `ARCHIVES_URL` set, it will default to "archives.html" as in your original theme.

Thanks for the theme!  It looks great.

:+1: 
