### PR TITLE
Added Piwik Tracking Code

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -124,5 +124,27 @@
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
 <script src="{{ SITEURL }}/theme/js/respond.min.js"></script>
 {% include 'includes/disqus_script.html' %}
+
+{% if PIWIK_SITE_ID and PIWIK_URL %}
+    {% if PIWIK_SSL_URL is not defined %}
+        {% set PIWIK_SSL_URL = PIWIK_URL %}
+    {% endif %}
+<!-- Piwik -->
+<script type="text/javascript">
+  var _paq = _paq || [];
+  _paq.push(["trackPageView"]);
+  _paq.push(["enableLinkTracking"]);
+
+  (function() {
+    var u=(("https:" == document.location.protocol) ? "https://{{ PIWIK_SSL_URL }}/" : "http://{{ PIWIK_URL }}/");
+    _paq.push(["setTrackerUrl", u+"piwik.php"]);
+    _paq.push(["setSiteId", "{{ PIWIK_SITE_ID }}"]);
+    var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
+    g.defer=true; g.async=true; g.src=u+"piwik.js"; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Piwik Code -->
+{% endif %}
+
 </body>
 </html>


### PR DESCRIPTION
I took the liberty of adding a block of code to allow for Piwik visitor tracking just like in the pelican default theme. It makes use of the variables mentioned in the pelican documentation:
- PIWIK_URL (required)
- PIWIK_SSL_URL (optional)
- PIWIK_SITE_ID (required)
