### PR TITLE
Moves jquery.js inclusion to the end

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -54,8 +54,6 @@
         <link href="{{ SITEURL }}/theme/css/typogrify.css" rel="stylesheet">
     {% endif %}
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/style.css" type="text/css"/>
-    <!-- JavaScript plugins (requires jQuery) -->
-    <script src="http://code.jquery.com/jquery.js"></script>
 
     {% if FEED_ALL_ATOM %}
         <link href="{{ SITEURL }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate"
@@ -133,6 +131,9 @@
     </div>
 </div>
 {% include 'includes/footer.html' %}
+
+<!-- JavaScript plugins (requires jQuery) -->
+<script src="http://code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
 <script src="{{ SITEURL }}/theme/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Moving the jquery.js inclusion to the end of the <body> tag improves page loading speed. The basic template from the Bootstrap page (http://getbootstrap.com/getting-started/#template) also does this.
