### PR TITLE
Word break in sidebar.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -131,7 +131,7 @@
         {% endblock %}
         </div>
 	{% if not HIDE_SIDEBAR %}
-        <div class="col-sm-3 well well-sm wordbreak" id="sidebar">
+        <div class="col-sm-3 well well-sm" id="sidebar">
             {% include 'includes/sidebar.html' %}
         </div>
 	{% endif %}


### PR DESCRIPTION
Beak the long word in sidebar, e.g., super loooooooooooooooooooooooooong tag.

![superlooooongtag](http://i.imgur.com/Tx5rT3u.png)

Ref: http://kenneth.io/blog/2012/03/04/word-wrapping-hypernation-using-css/
