### PR TITLE
De-global padding of font-awesome icons.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -34,8 +34,8 @@ body {
     color: inherit;
 }
 
-i {
-    margin-right: 10px;
+.icon-label {
+    margin-left: 10px;
 }
 
 a, a:hover {

--- a/templates/base.html
+++ b/templates/base.html
@@ -107,7 +107,7 @@
                 {% endif %}
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="{{ SITEURL }}/{{ ARCHIVES_URL | default('archives.html') }}"><i class="fa fa-th-list"></i>Archives</a></li>
+                <li><a href="{{ SITEURL }}/{{ ARCHIVES_URL | default('archives.html') }}"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->

--- a/templates/includes/article_info.html
+++ b/templates/includes/article_info.html
@@ -1,12 +1,12 @@
 <footer class="post-info">
     <span class="label label-default">Date</span>
     <span class="published">
-        <i class="fa fa-calendar"></i><time datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time>
+        <i class="fa fa-calendar"></i><time datetime="{{ article.date.isoformat() }}"> {{ article.locale_date }}</time>
     </span>
     {# Uncomment if you want the author shown #}
     {#{% if article.author %}#}
     {#<span class="label">By</span>#}
-    {#<a href="{{ SITEURL }}/{{ article.author.url }}"><i class="fa fa-user"></i>{{ article.author }}</a>#}
+    {#<a href="{{ SITEURL }}/{{ article.author.url }}"><i class="fa fa-user"></i> {{ article.author }}</a>#}
     {#{% endif %}#}
 
     {# Uncomment if you want to show Categories#}

--- a/templates/includes/links.html
+++ b/templates/includes/links.html
@@ -1,5 +1,5 @@
 {% if LINKS %}
-    <li class="list-group-item"><h4><i class="fa fa-external-link-square fa-lg"></i>Links</h4></li>
+    <li class="list-group-item"><h4><i class="fa fa-external-link-square fa-lg"></i><span class="icon-label">Links</span></h4></li>
     {% for name, link in LINKS %}
         <li class="list-group-item">
             <a href="{{ link }}" target="_blank">

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -6,10 +6,10 @@
     <section>
         <ul class="list-group list-group-flush">
             {% if SOCIAL %}
-                <li class="list-group-item"><h4><i class="fa fa-home fa-lg"></i>Social</h4></li>
+                <li class="list-group-item"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Social</span></h4></li>
                 {% for name, link in SOCIAL %}
                     <li class="list-group-item"><a href="{{ link }}"><i
-                            class="fa fa-{{ name|lower|replace('+','-plus') }}-square fa-lg"></i>{{ name }}
+                            class="fa fa-{{ name|lower|replace('+','-plus') }}-square fa-lg"></i> {{ name }}
                     </a></li>
                 {% endfor %}
             {% endif %}
@@ -18,7 +18,7 @@
                 {% if RECENT_POST_COUNT is not defined %}
                     {% set RECENT_POST_COUNT = 5 %}
                 {% endif %}
-                <li class="list-group-item"><h4><i class="fa fa-home fa-lg"></i>Recent Posts</h4></li>
+                <li class="list-group-item"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Recent Posts</span></h4></li>
                     {% for article in articles[:RECENT_POST_COUNT] %}
                         <li class="list-group-item">
                             <a href="{{ SITEURL }}/{{ article.url }}">
@@ -29,18 +29,19 @@
             {% endif %}
 
             {% if DISPLAY_CATEGORIES_ON_SIDEBAR %}
-                <li class="list-group-item"><a href="{{ SITEURL }}/{{ CATEGORIES_URL }}"><h4><i class="fa fa-home fa-lg"></i>Categories</h4></a></li>
+                <li class="list-group-item"><a href="{{ SITEURL }}/{{ CATEGORIES_URL }}"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Categories</span></h4></a></li>
+
                     {% for cat, null in categories %}
                         <li class="list-group-item">
                             <a href="{{ SITEURL }}/{{ cat.url }}">
-                                <i class="fa fa-folder-open fa-lg"></i>{{ cat }}
+                                <i class="fa fa-folder-open fa-lg"></i> {{ cat }}
                             </a>
                         </li>
                     {% endfor %}
             {% endif %}
 
             {% if DISPLAY_TAGS_ON_SIDEBAR %}
-                <li class="list-group-item"><a href="{{ SITEURL }}/{{ TAGS_URL }}"><h4><i class="fa fa-tags fa-lg"></i>Tags</h4></a></li>
+                <li class="list-group-item"><a href="{{ SITEURL }}/{{ TAGS_URL }}"><h4><i class="fa fa-tags fa-lg"></i><span class="icon-label">Tags</span></h4></a></li>
                     {% for tag in tag_cloud|sort(attribute='1') %}
                         <li class="list-group-item tag-{{ tag.1 }}">
                             <a href="{{ SITEURL }}/{{ tag.0.url }}">


### PR DESCRIPTION
Padding all font-awesome icons to the right on a site-wide basis means we can't have unpadded icons anymore. We change this to a label class that has the identical margin to the left.

Also, for some icons, we simply use a space, because the full spacing seems excessive.
