### PR TITLE
Some basic styling for figures and their captions.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -57,6 +57,27 @@ a, a:hover {
     height: auto;
 }
 
+.entry-content figcaption {
+    font-size: small;
+    margin-bottom: 2px;
+}
+
+.floatright {
+    float: right;
+}
+
+.floatleft {
+    float: left;
+}
+
+figure.floatright {
+    margin-left: 4px;
+}
+
+figure.floatleft {
+    margin-right: 4px;
+}
+
 .highlight pre {
     background-color: #202020;
     color: #777;


### PR DESCRIPTION
There was no styling for the figure and figcaption elements yet, and the default spacing seemed a little too tight for floating figures. You can see this (in the floatright version) in action on my blog:
http://lappland.io/blog/2014/01/data-flirting-or-saving-beautiful-tree/

The corresponding code one would be using in a markdown file [can be found here](https://github.com/hlapp/hlapp.github.io/blame/622c3d64c843d91773406e87f03481c60071f3c0/content/articles/data-flirting-or-beautiful-tree.md#L22-25).
