### PR TITLE
Sidebar nested lists

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -50,6 +50,12 @@ body {
     margin-left: 10px;
 }
 
+/* Example for how to control spacing between icon and label in specific
+   lists in the sidebar. To change, override in your CUSTOM_CSS           */
+#sidebar #social i {
+    margin-right: 3px;
+}
+
 a, a:hover {
     color: inherit;
 }

--- a/templates/includes/links.html
+++ b/templates/includes/links.html
@@ -1,6 +1,6 @@
 {% if LINKS %}
     <li class="list-group-item"><h4><i class="fa fa-external-link-square fa-lg"></i><span class="icon-label">Links</span></h4>
-      <ul class="list-group">
+      <ul class="list-group" id="links">
         {% for name, link in LINKS %}
         <li class="list-group-item">
             <a href="{{ link }}" target="_blank">

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -7,7 +7,7 @@
         <ul class="list-group list-group-flush">
             {% if SOCIAL %}
                 <li class="list-group-item"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Social</span></h4>
-                  <ul class="list-group">
+                  <ul class="list-group" id="social">
                     {% for name, link in SOCIAL %}
                     <li class="list-group-item"><a href="{{ link }}"><i
                             class="fa fa-{{ name|lower|replace('+','-plus') }}-square fa-lg"></i> {{ name }}
@@ -22,7 +22,7 @@
                     {% set RECENT_POST_COUNT = 5 %}
                 {% endif %}
                 <li class="list-group-item"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Recent Posts</span></h4>
-                    <ul class="list-group">
+                    <ul class="list-group" id="recentposts">
                     {% for article in articles[:RECENT_POST_COUNT] %}
                         <li class="list-group-item">
                             <a href="{{ SITEURL }}/{{ article.url }}">
@@ -36,7 +36,7 @@
 
             {% if DISPLAY_CATEGORIES_ON_SIDEBAR %}
                 <li class="list-group-item"><a href="{{ SITEURL }}/{{ CATEGORIES_URL }}"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Categories</span></h4></a>
-                    <ul class="list-group">
+                    <ul class="list-group" id="categories">
                     {% for cat, null in categories %}
                         <li class="list-group-item">
                             <a href="{{ SITEURL }}/{{ cat.url }}">
@@ -49,7 +49,7 @@
 
             {% if DISPLAY_TAGS_ON_SIDEBAR %}
                 <li class="list-group-item"><a href="{{ SITEURL }}/{{ TAGS_URL }}"><h4><i class="fa fa-tags fa-lg"></i><span class="icon-label">Tags</span></h4></a>
-                    <ul class="list-group">
+                    <ul class="list-group" id="tags">
                     {% for tag in tag_cloud|sort(attribute='1') %}
                         <li class="list-group-item tag-{{ tag.1 }}">
                             <a href="{{ SITEURL }}/{{ tag.0.url }}">


### PR DESCRIPTION
Moving sublists in the sidebar into nested `list-group`s. The implementation includes specific IDs for each nested sublist, allowing individual control of each sublist's styling. This addresses #47.
