### PR TITLE
Adds inline tags (tagcloud)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ SOCIAL = (('twitter', 'http://twitter.com/DaanDebie'),
           ('github', 'http://github.com/DandyDev'),)
 ```
 * **Tags** will be shown if `DISPLAY_TAGS_ON_SIDEBAR` is set to _True_
+* **Inline Tags (tagcloud)** will be shown if `DISPLAY_TAGS_INLINE` is set to _True_
 * **Categories** will be shown if `DISPLAY_CATEGORIES_ON_SIDEBAR` is set to _True_
 * **Recent Posts** will be shown if `DISPLAY_RECENT_POSTS_ON_SIDEBAR` is set to _True_
 	* Use `RECENT_POST_COUNT` to control the amount of recent posts. Defaults to **5**

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -150,3 +150,6 @@ figure.floatcenter, .align-center {
     margin-right: 10px;
 }
 
+.tagcloud li {
+    padding: 0px;
+}

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -48,9 +48,14 @@
             {% endif %}
 
             {% if DISPLAY_TAGS_ON_SIDEBAR %}
+                {% if DISPLAY_TAGS_INLINE %}
+                    {% set tags = tag_cloud | sort(attribute='0') %}
+                {% else %}
+                    {% set tags = tag_cloud | sort(attribute='1') %}
+                {% endif %}
                 <li class="list-group-item"><a href="{{ SITEURL }}/{{ TAGS_URL }}"><h4><i class="fa fa-tags fa-lg"></i><span class="icon-label">Tags</span></h4></a>
-                    <ul class="list-group" id="tags">
-                    {% for tag in tag_cloud|sort(attribute='1') %}
+                    <ul class="list-group {% if DISPLAY_TAGS_INLINE %}list-inline tagcloud{% endif %}" id="tags">
+                    {% for tag in tags %}
                         <li class="list-group-item tag-{{ tag.1 }}">
                             <a href="{{ SITEURL }}/{{ tag.0.url }}">
                                 {{ tag.0 }}


### PR DESCRIPTION
Setting `DISPLAY_TAGS_INLINE = True` will cause the theme to render all tags inline in the sidebar.
