### PR TITLE
Adds basic authors and author page

### DIFF
--- a/templates/author.html
+++ b/templates/author.html
@@ -1,9 +1,13 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body>
+{% extends "index.html" %}
 
-</body>
-</html>
+{% block title %}Articles by {{ author }} - {{ SITENAME }}{% endblock %}
+
+{% block breadcrumbs %}
+    {% if DISPLAY_BREADCRUMBS %}
+        <ol class="breadcrumb">
+            <li><a href="{{ SITEURL }}" title="{{ SITENAME }}"><i class="fa fa-home fa-lg"></i></a></li>
+            <li><a href="{{ SITEURL }}/{{ AUTHORS_URL|default('authors.html') }}" title="Authors">Authors</a></li>
+            <li class="active">{{ AUTHOR }}</li>
+        </ol>
+    {% endif %}
+{% endblock %}

--- a/templates/authors.html
+++ b/templates/authors.html
@@ -1,9 +1,19 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body>
+{% extends "base.html" %}
 
-</body>
-</html>
+{% block title %}Authors - {{ SITENAME }}{% endblock %}
+
+{% block breadcrumbs %}
+    {% if DISPLAY_BREADCRUMBS %}
+        <ol class="breadcrumb">
+            <li><a href="{{ SITEURL }}" title="{{ SITENAME }}"><i class="fa fa-home fa-lg"></i></a></li>
+            <li class="active">Authors</li>
+        </ol>
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    <h1>Authors on {{ SITENAME }}</h1>
+    {% for author, articles in authors|sort %}
+        <li><a href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a> ({{ articles|count }})</li>
+    {% endfor %}
+{% endblock %}


### PR DESCRIPTION
Just a simple page, the blank one was really dull :).

For those who doesn't want to render Author/Authors page set `AUTHOR_SAVE_AS = False` and `AUTHORS_SAVE_AS = False` in your pelican config file.
