### PR TITLE
Update pagination to respect PAGINATION_PATTERNS.

### DIFF
--- a/templates/includes/pagination.html
+++ b/templates/includes/pagination.html
@@ -7,10 +7,10 @@
         {% else %}
             <li class="prev disabled"><a href="#">&laquo;</a></li>
         {% endif %}
-        {% for num in range( 1, 1 + articles_paginator.num_pages ) %}
-                <li class="{{ 'active' if num == articles_page.number else '' }}"><a
-                        href="{{ SITEURL }}/{{ page_name }}{{ num if num > 1 else '' }}.html">{{ num }}</a></li>
-            {% endfor %}
+        {% for num in articles_paginator.page_range %}
+            <li class="{{ 'active' if num == articles_page.number else '' }}">
+               <a href="{{ SITEURL }}/{{ articles_paginator.page(num).url }}">{{ num }}</a></li>
+        {% endfor %}
         {% if articles_page.has_next() %}
             <li class="next"><a
                     href="{{ SITEURL }}/{{ articles_next_page.url }}">&raquo;</a></li>


### PR DESCRIPTION
Hi. I love your theme. I'm new to Pelican. I installed Pelican 3.3 and started using your theme. I noticed the pagination didn't work. I think it was because I had set my PAGINATION_PATTERNS like this:

````python
PAGINATION_PATTERNS = [
    (1, '{base_name}/', '{base_name}/index.html'),
    (2, '{base_name}/page/{number}/', '{base_name}/page/{number}/index.html'),
]
````

This wasn't what the pagination.html template was expecting. I am not sure if PAGINATION_PATTERNS is a new setting or not.

I did a bit of digging around in the Pelican code and came up with the pull request which works for me. I'm new to git and GitHub and this is my first pull request so please let me know if I messed something up. Thanks for the theme in any event!