### PR TITLE
Fix tag CSS; missing tag-0, duplicates for tag-2

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -22,6 +22,10 @@ body {
     border: none;
 }
 
+.tag-0 {
+    font-size: 16pt;
+}
+
 .tag-1 {
     font-size: 13pt;
 }
@@ -30,7 +34,7 @@ body {
     font-size: 10pt;
 }
 
-.tag-2 {
+.tag-3 {
     font-size: 8pt;
 }
 


### PR DESCRIPTION
I noticed there was no CSS style for tag-0. Also, there were two CSS definitions for tag-2, and none for tag-3.
