### PR TITLE
adding DISPLAY_ARTICLE_INFO_ON_INDEX option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ This theme has support for the [Related Posts plugin](https://github.com/getpeli
 
 Set the `FAVICON` option in your `pelicanconf.py`. For example: `FAVICON = 'images/favicon.png'`
 
+### index page options
+
+* article info (date, tags) will be show with the title for each article, if `DISPLAY_ARTICLE_INFO_ON_INDEX` is set to _True_
+
 ### Sidebar options
 
 The following things can be displayed on the sidebar:

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,11 @@
         {% for article in (articles_page.object_list if articles_page else articles) %}
             <article>
                 <h2><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h2>
+                {% if DISPLAY_ARTICLE_INFO_ON_INDEX %}
+                    <div class="well well-sm">
+                        {% include "includes/article_info.html" %}
+                    </div>
+                {% endif %}
                 <div class="summary">{{ article.summary }}
                     {% include 'includes/comment_count.html' %}
                     <a class="btn btn-default btn-xs" href="{{ SITEURL }}/{{ article.url }}">more ...</a>


### PR DESCRIPTION
This adds a configuration option to allow showing the article info under article titles on index pages. I can understand it's a preference to show this or not, but it would be nice so readers know how recent my posts are. 
