### PR TITLE
adding ABOUT_ME, SHOW_ABOUTME, and AVATAR options

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ This theme has support for the [Related Posts plugin](https://github.com/getpeli
 
 Set the `FAVICON` option in your `pelicanconf.py`. For example: `FAVICON = 'images/favicon.png'`
 
+### About Me options
+
+The following things can be displayed on the about me:
+
+* Your avatar will be the location that `AVATAR` is set to (e.g. 'images/profile.png')
+* Your aboutme paragraph will be whatever the `ABOUT_ME` variable is set to (raw html is allowed)
+
+To remove the aboutme entirely, set `SHOW_ABOUTME` to _False_ (default _False_)
+
 ### Sidebar options
 
 The following things can be displayed on the sidebar:

--- a/templates/base.html
+++ b/templates/base.html
@@ -119,7 +119,7 @@
 
 <div class="container">
     <div class="row">
-        {% if not HIDE_SIDEBAR %}
+        {% if not HIDE_SIDEBAR or SHOW_ABOUTME %}
         <div class="col-sm-9">
         {% else %}
         <div class="col-lg-12">
@@ -130,6 +130,11 @@
         {% block content %}
         {% endblock %}
         </div>
+	{% if SHOW_ABOUTME %}
+        <div class="col-sm-3" id="aboutme">
+            {% include 'includes/aboutme.html' %}
+        </div>
+	{% endif %}
 	{% if not HIDE_SIDEBAR %}
         <div class="col-sm-3 well well-sm" id="sidebar">
             {% include 'includes/sidebar.html' %}

--- a/templates/includes/aboutme.html
+++ b/templates/includes/aboutme.html
@@ -1,0 +1,11 @@
+{% if AVATAR %}
+<p>
+<img width="100%" class="img-thumbnail" src="{{ AVATAR }}"/>
+</p>
+{% endif %}
+{% if ABOUT_ME %}
+<p>
+  <strong>About {{ AUTHOR }}</strong><br/>
+  {{ ABOUT_ME }}
+</p>
+{% endif %}


### PR DESCRIPTION
This adds an optional "about me" section, directly above the sidebar, on the blog. 

by default it is off (using the SHOW_ABOUTME option), and allows one to add either an avatar image, an aboutme blurb, or both.
