### PR TITLE
Fix .highlighttable width

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -123,7 +123,7 @@ figure.floatcenter, .align-center {
     margin-bottom: 11px;
 }
 
-.highlighttable .code {
+.highlighttable {
     width: 100%;
 }
 


### PR DESCRIPTION
When using the '.highlighttable .code' selector, resulted in a squeezed line number column.
