### PR TITLE
Fix author label background being invisible

### DIFF
--- a/templates/includes/article_info.html
+++ b/templates/includes/article_info.html
@@ -5,7 +5,7 @@
     </span>
     {# Uncomment if you want the author shown #}
     {#{% if article.author %}#}
-    {#<span class="label">By</span>#}
+    {#<span class="label label-default">By</span>#}
     {#<a href="{{ SITEURL }}/{{ article.author.url }}"><i class="fa fa-user"></i> {{ article.author }}</a>#}
     {#{% endif %}#}
 


### PR DESCRIPTION
This one-liner fixes the background of "By" label if listing of the author in the article info bar is enabled.
