### PR TITLE
fix flickr-icon

### DIFF
--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -9,9 +9,12 @@
                 <li class="list-group-item"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Social</span></h4>
                   <ul class="list-group" id="social">
                     {% for name, link in SOCIAL %}
-                    <li class="list-group-item"><a href="{{ link }}"><i
-                            class="fa fa-{{ name|lower|replace('+','-plus') }}-square fa-lg"></i> {{ name }}
-                    </a></li>
+                        {% set name_sanitized = name|lower|replace('+','-plus') %}
+                        {% set iconattributes = '"fa fa-' ~ name_sanitized ~ '-square fa-lg"' %}
+                        {% if name_sanitized == 'flickr' %}
+                            {% set iconattributes = '"fa fa-' ~ name_sanitized ~ ' fa-lg"' %}
+                        {% endif %}
+                    <li class="list-group-item"><a href="{{ link }}"><i class={{ iconattributes }}></i> {{ name }}</a></li>
                     {% endfor %}
                   </ul>
                 </li>


### PR DESCRIPTION
adds functionality to use social icons that don't use the square notation, see issue #86
-  implemented flickr fix

![flickr_fix](https://cloud.githubusercontent.com/assets/4435962/3013443/addda684-df48-11e3-9b0b-a7effd2599ae.PNG)
