### PR TITLE
Add syntax coloring from `highlighting-kate` (used by PanDoc)

### DIFF
--- a/static/css/pygments/hk-espresso.css
+++ b/static/css/pygments/hk-espresso.css
@@ -1,0 +1,19 @@
+/* Based on ultraviolet's espresso_libre.css */
+table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode, table.sourceCode pre
+   { margin: 0; padding: 0; border: 0; vertical-align: baseline; border: none; }
+td.lineNumbers { border-right: 1px solid #AAAAAA; text-align: right; color: #AAAAAA; padding-right: 5px; padding-left: 5px; }
+code.sourceCode, pre.sourceCode, table.sourceCode { background-color: #2A211C; color: #BDAE9D; }
+td.sourceCode { padding-left: 5px; }
+code.sourceCode span.kw { color: #43A8ED; font-weight: bold; }
+code.sourceCode span.dt { text-decoration: underline; }
+code.sourceCode span.dv { color: #44AA43; }
+code.sourceCode span.bn { color: #44AA43; }
+code.sourceCode span.fl { color: #44AA43; }
+code.sourceCode span.ch { color: #049B0A; }
+code.sourceCode span.st { color: #049B0A; }
+code.sourceCode span.co { color: #0066FF; font-style: italic; }
+code.sourceCode span.ot { }
+code.sourceCode span.al { color: yellow; font-weight: bold; }
+code.sourceCode span.fu { color: #FF9358; font-weight: bold; }
+code.sourceCode span.re { }
+code.sourceCode span.er { color: yellow; font-weight: bold; }

--- a/static/css/pygments/hk-kate.css
+++ b/static/css/pygments/hk-kate.css
@@ -1,0 +1,19 @@
+/* Based on kate's own default colors for Haskell */
+table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode, table.sourceCode pre
+   { margin: 0; padding: 0; border: 0; vertical-align: baseline; border: none; }
+td.lineNumbers { text-align: right; background-color: #EBEBEB; color: black; padding-right: 5px; padding-left: 5px; }
+td.sourceCode { padding-left: 5px; }
+pre.sourceCode { }
+code.sourceCode span.kw { font-weight: bold; }
+code.sourceCode span.dt { color: #800000; }
+code.sourceCode span.dv { color: #0000FF; }
+code.sourceCode span.bn { color: #0000FF; }
+code.sourceCode span.fl { color: #800080; }
+code.sourceCode span.ch { color: #FF00FF; }
+code.sourceCode span.st { color: #DD0000; }
+code.sourceCode span.co { color: #808080; font-style: italic; }
+code.sourceCode span.ot { }
+code.sourceCode span.al { color: green; font-weight: bold; }
+code.sourceCode span.fu { color: #000080; }
+code.sourceCode span.re { }
+code.sourceCode span.er { color: red; font-weight: bold; }

--- a/static/css/pygments/hk-pyg.css
+++ b/static/css/pygments/hk-pyg.css
@@ -1,0 +1,19 @@
+/* Loosely based on pygment's default colors */
+table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode, table.sourceCode pre
+   { margin: 0; padding: 0; border: 0; vertical-align: baseline; border: none; }
+td.lineNumbers { border-right: 1px solid #AAAAAA; text-align: right; color: #AAAAAA; padding-right: 5px; padding-left: 5px; }
+td.sourceCode { padding-left: 5px; }
+pre.sourceCode { }
+code.sourceCode span.kw { color: #007020; font-weight: bold; }
+code.sourceCode span.dt { color: #902000; }
+code.sourceCode span.dv { color: #40a070; }
+code.sourceCode span.bn { color: #40a070; }
+code.sourceCode span.fl { color: #40a070; }
+code.sourceCode span.ch { color: #4070a0; }
+code.sourceCode span.st { color: #4070a0; }
+code.sourceCode span.co { color: #60a0b0; font-style: italic; }
+code.sourceCode span.ot { color: #007020; }
+code.sourceCode span.al { color: red; font-weight: bold; }
+code.sourceCode span.fu { color: #06287e; }
+code.sourceCode span.re { }
+code.sourceCode span.er { color: red; font-weight: bold; }

--- a/static/css/pygments/hk-tango.css
+++ b/static/css/pygments/hk-tango.css
@@ -1,0 +1,21 @@
+/* Loosely based on pygment's tango colors */
+table.sourceCode, tr.sourceCode, td.sourceCode, table.sourceCode pre
+   { margin: 0; padding: 0; border: 0; vertical-align: baseline; border: none; background-color: #f8f8f8 }
+td.nums { text-align: right; padding-right: 5px; padding-left: 5px; background-color: #f0f0f0; }
+td.sourceCode { padding-left: 5px; }
+code.sourceCode { background-color: #f8f8f8; }
+pre.sourceCode { background-color: #f8f8f8; line-height: 125% }
+td.nums pre { background-color: #f0f0f0; line-height: 125% }
+code.sourceCode span.kw { color: #204a87; font-weight: bold } /* Keyword */
+code.sourceCode span.dt { color: #204a87 } /* Keyword.Type */
+code.sourceCode span.dv { color: #0000cf } /* Literal.Number.Integer */
+code.sourceCode span.bn { color: #0000cf } /* Literal.Number.Hex */
+code.sourceCode span.fl { color: #0000cf } /* Literal.Number.Float */
+code.sourceCode span.ch { color: #4e9a06 } /* Literal.String.Char */
+code.sourceCode span.st { color: #4e9a06 } /* Literal.String */
+code.sourceCode span.co { color: #8f5902; font-style: italic } /* Comment */
+code.sourceCode span.ot { color: #8f5902 } /* Comment.Preproc */
+code.sourceCode span.al { color: #ef2929 } /* Generic.Error */
+code.sourceCode span.fu { color: #000000 } /* Name.Function */
+code.sourceCode span.re { }
+code.sourceCode span.er { color: #a40000; border: 1px solid #ef2929 } /* Error */


### PR DESCRIPTION
PanDoc (plugin [pandoc_reader](https://github.com/liob/pandoc_reader)) seems to be using `highlighting-kate` for syntax coloring, even with the `pygments` option. Consequently coloring in this theme does not work (everything is inside `.sourceCode` instead of `.highlight` and quite some things have been renamed -- eg. comments `.co` instead of `.c`).

I copied the styles from `highlighting-kate`: https://github.com/jgm/highlighting-kate/tree/master/css
