### PR TITLE
Add Twitter Cards tags to the theme. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,20 @@ To get a `TWITTER_WIDGET_ID`, go to: https://twitter.com/settings/widgets and se
 
 `https://twitter.com/settings/widgets/TWITTER_WIDGET_ID/edit`
 
+### Twitter Cards
+
+The theme can now add [Twitter Cards](https://dev.twitter.com/docs/cards) tag to your articles and pages. To enable Twitter Cards, provide a `TWITTER_CARDS_USERNAME` with yout Twitter userid.
+
+Since Twitter Cards requires a mandatory image that will displayed into the card itself, you have to add a new property to your article or page:
+
+```
+	:twitterimage: relative_path_to_twitter_image.ext
+```
+
+If that property is not provided, `FAVICON` will be used as fallback. If `FAVICON` is not provided, Twitter Cards will not be displayed (Twitter Cards tags will not be added to content).
+
+Please notice that, to display cards on Twitter, it is not sufficient to add tags to the content;it is also necessary to advice Twitter that your blog pages have to be parsed for Twitter Card tags. To do so, you have to connect to [Twitter Cards developer page](https://dev.twitter.com/docs/cards/validation/validator) and validate an article.
+
 ### Bootswatch and other Bootstrap 3 themes
 
 I included all the lovely Bootstrap 3 themes from [Bootswatch](http://bootswatch.com/), built by [Thomas Park](https://github.com/thomaspark). You can tell Pelican what Bootswatch theme to use, by setting `BOOTSTRAP_THEME` to the desired theme, in lowercase (ie. 'readable' or 'cosmo' etc.). My own site is using _Readable_. If you want to use any other Bootstrap 3 compatible theme, just put the minified CSS in the `static/css` directory and rename it using the following naming scheme: `bootstrap.{theme-name}.min.css`. Then update the `BOOTSTRAP_THEME` variable with the _theme-name_ used.

--- a/templates/article.html
+++ b/templates/article.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% block title %}{{ article.title|striptags }} - {{ SITENAME }}{% endblock %}
 
+{% set TWITTER_CARDS_VISIBLE = True %}
+
 {% block breadcrumbs %}
     {% if DISPLAY_BREADCRUMBS %}
         {% if DISPLAY_CATEGORY_IN_BREADCRUMBS %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,30 @@
     <link href="{{ SITEURL }}/{{ FAVICON }}" rel="icon">
     {% endif %}
 
+    {# Twitter Cards tags #}
+    {% if TWITTER_CARDS_USERNAME is not defined %}
+        {% set TWITTER_CARDS_USERNAME = False %}
+    {% endif %}
+    {% if TWITTER_CARDS_VISIBLE is not defined %}
+        {% set TWITTER_CARDS_VISIBLE = False %}
+    {% endif %}
+
+    {% block twitter_cards %}
+        {% if TWITTER_CARDS_USERNAME and TWITTER_CARDS_VISIBLE %}
+            {% if article.twitterimage or FAVICON %}
+            <!-- Twitter Cards tags -->
+            <meta property="twitter:card" content="summary" />
+            <meta property="twitter:site" content="@{{ TWITTER_CARDS_USERNAME }}" />
+            <meta property="twitter:creator" content="@{{ TWITTER_CARDS_USERNAME }}" />
+            <meta property="twitter:domain" content="{{ SITEURL }}" />
+            <meta property="twitter:title" content="{{ article.title|striptags }}" />
+            <meta property="twitter:description" content="{{ article.summary|striptags|escape }}" />
+            <meta property="twitter:url" content="{{ SITEURL }}/{{ article.url }}" />
+            <meta property="twitter:image" content="{{ SITEURL }}/{{ article.twitterimage or FAVICON }}" />
+            {% endif %}
+        {% endif %}
+    {% endblock %}
+
     {# Open Graph tags #}
     {% if USE_OPEN_GRAPH is not defined %}
         {% set USE_OPEN_GRAPH = True %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,6 +1,23 @@
 {% extends "base.html" %}
 {% block title %}{{ page.title }} - {{ SITENAME }}{% endblock %}
 
+{% set TWITTER_CARDS_VISIBLE = True %}
+
+    {% block twitter_cards %}
+            {% if page.twitterimage or FAVICON %}
+            <!-- Twitter Cards tags -->
+            <meta property="twitter:card" content="summary" />
+            <meta property="twitter:site" content="@{{ TWITTER_CARDS_USERNAME }}" />
+            <meta property="twitter:creator" content="@{{ TWITTER_CARDS_USERNAME }}" />
+            <meta property="twitter:domain" content="{{ SITEURL }}" />
+            <meta property="twitter:title" content="{{ page.title|striptags }}" />
+            <meta property="twitter:description" content="{{ page.summary|striptags|escape }}" />
+            <meta property="twitter:url" content="{{ SITEURL }}/{{ page.url }}" />
+            <meta property="twitter:image" content="{{ SITEURL }}/{{ page.twitterimage or FAVICON }}" />
+            {% endif %}
+        {% endif %}
+    {% endblock %}
+
 {% block breadcrumbs %}
     {% if DISPLAY_BREADCRUMBS %}
     <ol class="breadcrumb">


### PR DESCRIPTION
Now it is possible to activate Twitter Cards for articles and pages.

I also updated the README.md with configuration data and explanation.

Twitter cards are active on [my blog](http://blog.towerengineering.it).
