### PR TITLE
Sort headline pages by 'SortOrder'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ You can optionally declare a [Creative Commons license](http://creativecommons.o
 
 The license choice mirrors the [Creative Commons License Chooser](http://creativecommons.org/choose/). Source for the macro that renders the mark is at http://github.com/hlapp/cc-tools.
 
+### Sorted pages
+
+The pages in the header row can be sorted by giving them a `SortOrder` attribute.
+
+
 ### GitHub
 
 The theme can show your most recently active GitHub repos in the sidebar. To enable, provide a `GITHUB_USER`. Appearance and behaviour can be controlled using the following variables:

--- a/templates/base.html
+++ b/templates/base.html
@@ -108,7 +108,7 @@
                     <li><a href="{{ link }}">{{ title }}</a></li>
                 {% endfor %}
                 {% if DISPLAY_PAGES_ON_MENU %}
-                    {% for p in PAGES %}
+                    {% for p in PAGES|sort(attribute='sortorder') %}
                          <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">
                              {{ p.menulabel|default(p.title) }}
                           </a></li>


### PR DESCRIPTION
Pages in the headline are now ordered by their property 'SortOrder'. If the pages have no SortOrder attribute, they are not sorted (old behaviour).

To enable this feature add a numeric SortOrder attribute to the pages.