### PR TITLE
Adds page.AddtoMenu to controll appearance in menu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ for the menu (such as a short single word) than the page title by adding a
 Menulabel metadata attribute to the page header (`Menulabel:` in
 markdown, `:Menulabel:` in rst).
 
+### Hide pages from menu
+
+By default, pages are shown in the menu, if the pages menu is enabled.
+This can be changed by adding the page metadata attribute `AddToMenu`.
+
+If set to `True` (default), then the page will be shown in the menu. 
+If set to `False` (or anything != True), the page will not be shown in the menu.
+
 ### About Me
 
 You can show a short blurb of text about yourself and a picture. The following two settings are used for this:

--- a/templates/base.html
+++ b/templates/base.html
@@ -109,9 +109,11 @@
                 {% endfor %}
                 {% if DISPLAY_PAGES_ON_MENU %}
                     {% for p in PAGES %}
-                         <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">
+                         {% if p.addtomenu is undefined or p.addtomenu == "True" %}
+                             <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">
                              {{ p.menulabel|default(p.title) }}
-                          </a></li>
+                             </a></li>
+                          {% endif %}
                       {% endfor %}
                 {% endif %}
                 {% if DISPLAY_CATEGORIES_ON_MENU %}


### PR DESCRIPTION
By default, pages are shown in the menu, if the pages menu is enabled.
This can be changed by adding the page metadata attribute `AddToMenu`.
