### PR TITLE
Set image width to 100% for article lists

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -98,6 +98,12 @@ a, a:hover {
     margin-bottom: 2px;
 }
 
+.summary img {
+    max-width: 100%;
+    height: auto;
+}
+
+
 .floatright, .align-right {
     float: right;
 }


### PR DESCRIPTION
On article lists, large images were being shown as full size rather than being resized to 100% of the parent container - this was a different to the article page which works as expected. I doubt that this will break any existing sites, so have created a straight pull request for inclusion on the main branch.
