### PR TITLE
Updating EXAMPLES.md to include beneathdata.com custom example

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -13,6 +13,8 @@ If your website is listed here, but you don't want it to be, let me know and I'l
 
 [Mind Bending](http://mindbending.org/en) by [magnunleno](https://github.com/magnunleno) - Heavily customized design based on pelican-bootstrap3 with lots of stuff added. Some of that stuff was neatly contributed back to pelican-boostrap3.
 
+[Beneath Data](http://beneathdata.com) by [tylerhartley](https://github.com/tylerhartley) - Customized pelican-boostrap3 to include a homepage banner, a footer containing the "About Me" and other social content, plus other small UI tweaks.
+
 [toumorokoshi](http://toumorokoshi.github.io/) by [toumorokoshi](https://github.com/toumorokoshi) - Clean version of pelican-bootstrap3 with a nice profile area added in.
 
 [Christine Doig](http://chdoig.github.io/) by [chdoig](https://github.com/chdoig) - Barely recognizable anymore as pelican-boostrap3, but it is in fact [based on this theme](http://chdoig.github.io/create-pelican-blog.html). The Twitter widget has been contributed back to pelican-bootstrap3


### PR DESCRIPTION
I'd love to add my site to the pelican-boostrap3 examples list if that's ok. This has been been an outstanding framework to work with! 

This might also be a good place to ask if the banner implemented on my site would be a welcome addition to pelican-bootstrap3 as an optional setting. The idea came from Jekyll's [Cactus](http://wolfr.github.io/cactus-jekyll-theme/), which is one of the few clean, good-looking banners I've seen on a Bootstrap site. I'd need to do a bit more work to clean up my code before a PR, so before I go down that path let me know if you'd welcome the feature.
