### PR TITLE
Fixes deprecated MathJax URL

### DIFF
--- a/templates/includes/liquid_tags_nb_header.html
+++ b/templates/includes/liquid_tags_nb_header.html
@@ -135,7 +135,7 @@ div.text_cell_render {
 img.anim_icon{padding:0; border:0; vertical-align:middle; -webkit-box-shadow:none; -box-shadow:none}
 </style>
 
-<script src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript"></script>
++<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript"></script>
 <script type="text/javascript">
 init_mathjax = function() {
     if (window.MathJax) {


### PR DESCRIPTION
Use updated MathJax URL to work in both http and https.  Current URL returns a 404, the script is not loaded, and no math is displayed in ipython notebooks.

For more information, see:
getpelican/pelican-plugins@389bfdc3ece84c4efe5bd8e3b228f010256ac3e8
and
[Changes to the MathJax CDN](http://www.mathjax.org/changes-to-the-mathjax-cdn/)
