### PR TITLE
Facebook App ID shouldn't be a requirement for putting in OG meta tags

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -15,8 +15,10 @@
     {% endif %}
 {% endblock %}
 {% block opengraph %}
-    {% if OPEN_GRAPH_FB_APP_ID %}
-        <meta property="fb:app_id" content="{{ OPEN_GRAPH_FB_APP_ID }}"/>
+    {% if USE_OPEN_GRAPH %}
+        {% if OPEN_GRAPH_FB_APP_ID %}
+            <meta property="fb:app_id" content="{{ OPEN_GRAPH_FB_APP_ID }}"/>
+        {% endif %}
         <meta property="og:site_name" content="{{ SITENAME }}" />
         <meta property="og:type" content="article"/>
         <meta property="og:title" content="{{ article.title|striptags|escape }}"/>


### PR DESCRIPTION
Currently, articles don't get the OG meta tags if there isn't a configured `OPEN_GRAPH_FB_APP_ID`.

This PR changes the logic to match https://github.com/DandyDev/pelican-bootstrap3/commit/7a472b2f0a46265ccbc52a88741fde47783d1e03#diff-8944b57466f08564caa53a1988261ae0R31 and https://github.com/DandyDev/pelican-bootstrap3/commit/7a472b2f0a46265ccbc52a88741fde47783d1e03#diff-9cac001cb097f71f61611dfb8cccb374R5 to allow the tags to be created on an article without the `OPEN_GRAPH_FB_APP_ID`.
