### PR TITLE
Add drupal to list of not square social icons

### DIFF
--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -9,7 +9,7 @@
               <ul class="list-group" id="social">
                 {% for name, link in SOCIAL %}
                     {% set name_sanitized = name|lower|replace('+','-plus')|replace(' ','-') %}
-                    {% if name_sanitized in ['flickr', 'spotify', 'stack-overflow'] %}
+                    {% if name_sanitized in ['drupal', 'flickr', 'spotify', 'stack-overflow'] %}
                         {% set iconattributes = '"fa fa-' ~ name_sanitized ~ ' fa-lg"' %}
                     {% else %}
                         {% set iconattributes = '"fa fa-' ~ name_sanitized ~ '-square fa-lg"' %}


### PR DESCRIPTION
Add 'drupal' to the list of not square icons as a *-square version
of fa-drupal is not available in the current version of Font
Awesome (4.2).

Drupal has a community centred around drupal.org and users may
wish to include a link to their public user page in the list of social links.