### PR TITLE
Update search post URL for compatibility. fix #145

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -128,7 +128,7 @@
             <ul class="nav navbar-nav navbar-right">
             {% if 'tipue_search' in PLUGINS %}
               <li><span>
-                <form class="navbar-search" action="/search">
+                <form class="navbar-search" action="/search.html">
                   <input type="text" class="search-query" placeholder="Search" name="q" id="tipue_search_input" required>
                 </form></span>
               </li>


### PR DESCRIPTION
The current code for Tipue search require rewrite rule to work properly.
In some web host where rewrite rule is not supported (e.g. S3, CloudFiles) the search feature will not be able to function correctly.
Wouldn't it be better to post search data to html file directly?