### PR TITLE
allow the user to specify a app manifest in the pelicanconf.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ All you have to do, is:
 - Add `DIRECT_TEMPLATES = (('search',))` in your `pelicanconf.py`.
 
 
+### WebApp Manifest-Support
+
+This theme supports linking to a [App-Manifest](http://updates.html5rocks.com/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android). Create the file similiar to the custom.css file, than reference it's output path in `MANIFEST` like `MANIFEST = '/static/manifest.json'`
+
 ### Footer
 
 The footer will display a copyright message using the AUTHOR variable and the year of the latest post. If a content license mark is enabled (see above), that will be shown as well. 

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,6 +56,10 @@
     {# Twitter Cards tags #}
     {% include 'includes/twitter_cards.html' %}
 
+    {% if MANIFEST %}
+    <link rel="manifest" href="{{ MANIFEST }}">
+    {% endif %}
+
     <!-- Bootstrap -->
     {% if BOOTSTRAP_THEME %}
         <link rel="stylesheet" href="{{ SITEURL }}/theme/css/bootstrap.{{ BOOTSTRAP_THEME }}.min.css" type="text/css"/>


### PR DESCRIPTION
This allows to implement nicer app launchers in e.g. Chrome on Android.

http://updates.html5rocks.com/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android