### PR TITLE
Add support for <meta name="theme-color">

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ This theme supports including IPython notebooks through the [Liquid Tags plugin]
 
 Set the `FAVICON` option in your `pelicanconf.py`. For example: `FAVICON = 'images/favicon.png'`
 
+### Theme-Color for Chrome v39+ on Android Lollipop
+
+Set the `THEMECOLOR` option in your `pelicanconf.py`. For example: `THEMECOLOR = '#4B088A'`
+
 ### Index page
 
 * If `DISPLAY_ARTICLE_INFO_ON_INDEX` is set to _True_, article info (date, tags) will be show under the title for each article, otherwise only title and summary will be shown (default). 

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    {% if THEMECOLOR %}
+    <meta name="theme-color" content="{{ THEMECOLOR }}">
+    {% endif %}
     {% if 'liquid_tags.notebook' in PLUGINS %}
         {% include 'includes/liquid_tags_nb_header.html' %}
     {% endif %}


### PR DESCRIPTION
Android Lollipop and Chrome has support for styling the toolbar color.
This enables the user to specify the color as config option.

http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-Android