### PR TITLE
show more button only if article.summary not the same as article.content

### DIFF
--- a/templates/article_list.html
+++ b/templates/article_list.html
@@ -11,7 +11,9 @@
                 {% endif %}
                 <div class="summary">{{ article.summary }}
                     {% include 'includes/comment_count.html' %}
-                    <a class="btn btn-default btn-xs" href="{{ SITEURL }}/{{ article.url }}">more ...</a>
+		    {% if article.summary != article.content %}
+                       <a class="btn btn-default btn-xs" href="{{ SITEURL }}/{{ article.url }}">more ...</a>
+		    {% endif %}
                 </div>
             </article>
             <hr/>


### PR DESCRIPTION
If an article is very short the article.summary is the same as the article.content. In this case the "more" button is useless and can be omitted.