### PR TITLE
Tipue fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,7 @@ This theme has support for the
 All you have to do, is:
 - enable the plugin, and the theme will add a search box on the right
   side of the menu
-- Add `DIRECT_TEMPLATES = (('search',))` in your `pelicanconf.py`.
-
+- Add `'search'` to the `DIRECT_TEMPLATES` in your `pelicanconf.py`. E.g. `DIRECT_TEMPLATES = ('index', 'categories', 'authors', 'archives', 'search').
 
 ### Footer
 

--- a/templates/includes/minify_tipuesearch.html
+++ b/templates/includes/minify_tipuesearch.html
@@ -1,0 +1,3 @@
+{% assets filters="rjsmin", output="tipuesearch/tipuesearch.packed.min.js", "tipuesearch/tipuesearch_set.js", "tipuesearch/tipuesearch.js" %}
+<script type="text/javascript" src="{{ SITEURL }}/{{ ASSET_URL }}"></script>
+{% endassets %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -6,7 +6,7 @@ Search - {{ super() }}
 
 {% block scripts %}
     {% if 'assets' in PLUGINS %}
-    {% include '_includes/minify_tipuesearch.html' with context %}
+    {% include 'includes/minify_tipuesearch.html' with context %}
     {% else %}
     <link href="{{ SITEURL }}/theme/tipuesearch/tipuesearch.css" rel="stylesheet">
     <script type="text/javascript" src="{{ SITEURL }}/theme/tipuesearch/tipuesearch_set.js"></script>


### PR DESCRIPTION
Enabling both the `tipue_search` and `assets` plugins causes an Exception (missing template etc). I just copied the code from [here](https://github.com/talha131/pelican-elegant/blob/master/templates/_includes/minify_tipuesearch.html). Not sure if anything else is needed.