### PR TITLE
Define USE_OPEN_GRAPH before opening <html> tag

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="{% block html_lang %}{{ DEFAULT_LANG }}{% endblock %}"
-      {% if USE_OPEN_GRAPH %}
-      xmlns:og="http://ogp.me/ns#"
-      xmlns:fb="https://www.facebook.com/2008/fbml"{% endif %}>
+{% if USE_OPEN_GRAPH is not defined %}
+    {% set USE_OPEN_GRAPH = True %}
+{% endif %}
+<html lang="{% block html_lang %}{{ DEFAULT_LANG }}{% endblock %}"{% if USE_OPEN_GRAPH %} prefix="og: http://ogp.me/ns# fb: https://www.facebook.com/2008/fbml"{% endif %}>
 <head>
     <title>{% block title %}{{ SITENAME }}{% endblock %}</title>
     <!-- Using the latest rendering mode for IE -->
@@ -32,9 +32,6 @@
     {% endblock %}
 
     {# Open Graph tags #}
-    {% if USE_OPEN_GRAPH is not defined %}
-        {% set USE_OPEN_GRAPH = True %}
-    {% endif %}
     {% if USE_OPEN_GRAPH %}
     {% block opengraph %}
     <!-- Open Graph tags -->


### PR DESCRIPTION
Open Graph tags are rendered by default by setting USE_OPEN_GRAPH = True
if USE_OPEN_GRAPH is not defined. Moving set USE_OPEN_GRAPH to
immediately before the opening <html> tag enables the og and fb
namespaces by default also.

Change the namespace syntax from XHTML to the prefix attribute for valid
HTML5.