### PR TITLE
Add the hability to have a custom licence string in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ You can optionally declare a [Creative Commons license](http://creativecommons.o
 
 The license choice mirrors the [Creative Commons License Chooser](http://creativecommons.org/choose/). Source for the macro that renders the mark is at http://github.com/hlapp/cc-tools.
 
+Alternatively, if you want to use another license type, you can use instead the `CUSTOM_LICENSE` property to set a license string that will be added at the bottom of every page.
+Raw HTML is allowed.
+As `CC_*` variables take precedence, be sure to avoid `CC_*` variables when using `CUSTOM_LICENSE`.
+By example, if you want to use the WTFPL license, yuo can set:
+`CUSTOM_LICENSE='Unless otherwise stated, all articles are published under the <a href="http://www.wtfpl.net/about/">WTFPL</a> license.'`
+
 ### GitHub
 
 The theme can show your most recently active GitHub repos in the sidebar. To enable, provide a `GITHUB_USER`. Appearance and behaviour can be controlled using the following variables:

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ The license choice mirrors the [Creative Commons License Chooser](http://creativ
 Alternatively, if you want to use another license type, you can use instead the `CUSTOM_LICENSE` property to set a license string that will be added at the bottom of every page.
 Raw HTML is allowed.
 As `CC_*` variables take precedence, be sure to avoid `CC_*` variables when using `CUSTOM_LICENSE`.
-By example, if you want to use the WTFPL license, yuo can set:
+
+By example, if you want to use the WTFPL license, you can set:
 `CUSTOM_LICENSE='Unless otherwise stated, all articles are published under the <a href="http://www.wtfpl.net/about/">WTFPL</a> license.'`
 
 ### GitHub

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -14,6 +14,8 @@
             {%- if CC_LICENSE or CC_LICENSE_DERIVATIVES or CC_LICENSE_COMMERCIAL %}
               {% from 'includes/cc-license.html' import cc_license_mark %}
               <p><small>{{ cc_license_mark(cc_name=CC_LICENSE,derivatives=CC_LICENSE_DERIVATIVES,commercial=CC_LICENSE_COMMERCIAL,attr_markup=CC_ATTR_MARKUP,attr_props={'title':SITENAME,'name':article.author if article else AUTHOR,'url':SITEURL}) }}</small></p>
+            {% elif CUSTOM_LICENSE %}
+              <p><small>{{ CUSTOM_LICENSE }}</small></p>
             {% endif %}
          </div>
          <div class="col-xs-2"><p class="pull-right"><i class="fa fa-arrow-up"></i> <a href="#">Back to top</a></p></div>


### PR DESCRIPTION
This change add a new CUSTOM_LICENSE configuration item to let the user choose a different license than the Creative Commons License. Raw html can be used in this variable.
It is only used if CC variables are ommited.

I've used it to add a WTFPL notice in footer like this :
CUSTOM_LICENSE='Except where otherwise noted, all articles on this site are licensed under the <a href="http://www.wtfpl.net/about/">WTFPL</a> license'