### PR TITLE
added support for pelican-dynamic plugin

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -50,6 +50,17 @@
 <link rel="canonical" href="{{ SITEURL }}/{{ article.url }}">
 {% endblock %}
 
+
+{% block dynamic_css %}
+    {% if article.styles %}
+        {% for style in article.styles %}
+            {{ style }}
+        {% endfor %}
+    {% endif %}
+{% endblock %}
+
+
+
 {% block breadcrumbs %}
     {% if DISPLAY_BREADCRUMBS %}
         {% if DISPLAY_CATEGORY_IN_BREADCRUMBS %}
@@ -98,6 +109,13 @@
 {% endblock %}
 
 {% block scripts %}
+
+{% if article.scripts %}
+    {% for script in article.scripts %}
+        {{ script }}
+    {% endfor %}
+{% endif %}
+
 {% if ADDTHIS_PROFILE %}
     {% if ADDTHIS_DATA_TRACK_ADDRESSBAR|default(true) %}
         <script type="text/javascript">var addthis_config = {"data_track_addressbar": true};</script>
@@ -109,3 +127,4 @@
     <script src="{{ SITEURL }}/theme/js/shariff.min.js"></script>
 {% endif %}
 {% endblock %}
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -118,11 +118,11 @@
                     <li><a href="{{ link }}">{{ title }}</a></li>
                 {% endfor %}
                 {% if DISPLAY_PAGES_ON_MENU %}
-                    {% for p in PAGES %}
-                         <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">
-                             {{ p.menulabel|default(p.title) }}
-                          </a></li>
-                      {% endfor %}
+                    {% for p in PAGES|sort(attribute='sortorder') %}
+                        <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">
+                            {{ p.menulabel|default(p.title) }}
+                        </a></li>
+                    {% endfor %}
                 {% endif %}
                 {% if DISPLAY_CATEGORIES_ON_MENU %}
                     {% for cat, null in categories %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -91,6 +91,10 @@
               title="{{ SITENAME }} RSS Feed"/>
     {% endif %}
 
+
+    {% block dynamic_css %}{% endblock %}
+
+
 </head>
 <body>
 
@@ -195,5 +199,7 @@
 {% include 'includes/piwik.html' %}
 
 {% block scripts %}{% endblock %}
+
+
 </body>
 </html>

--- a/templates/page.html
+++ b/templates/page.html
@@ -44,6 +44,16 @@
     {% endif %}
 {% endblock %}
 
+
+{% block dynamic_css %}
+    {% if page.styles %}
+        {% for style in page.styles %}
+            {{ style }}
+        {% endfor %}
+    {% endif %}
+{% endblock %}
+
+
 {% block content %}
     <section id="content" class="body">
         <h1 class="entry-title">{{ page.title }}</h1>
@@ -61,4 +71,14 @@
             {% endif %}
         </div>
     </section>
+
 {% endblock %}
+
+
+{% block scripts %}
+    {% if page.scripts %}
+        {% for script in page.scripts %}
+            {{ script }}
+        {% endfor %}
+    {% endif %}
+{% endblock%}


### PR DESCRIPTION
Like the author of the [pelican-dynamic](https://github.com/wrobstory/pelican_dynamic) plugin, I also like the possibility of embedding D3 visualizations (in my case not only to posts---e.g. articles---but pages as well). I also love your bootstrap plugin. Here are my two cents, adding support for pelican-dynamic to both articles and pages.