### PR TITLE
Documented use of TAGS_URL setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ SOCIAL = (('twitter', 'http://twitter.com/DaanDebie'),
 ```
 * **Tags** will be shown if `DISPLAY_TAGS_ON_SIDEBAR` is set to _True_. Normally, tags are shown as a list.
 	* Set `DISPLAY_TAGS_INLINE` to _True_, to display the tags inline (ie. as tagcloud)
+	* Set `TAGS_URL` to the relative URL of the tags index page (typically `tags.html`)
 * **Categories** will be shown if `DISPLAY_CATEGORIES_ON_SIDEBAR` is set to _True_
 * **Recent Posts** will be shown if `DISPLAY_RECENT_POSTS_ON_SIDEBAR` is set to _True_
 	* Use `RECENT_POST_COUNT` to control the amount of recent posts. Defaults to **5**


### PR DESCRIPTION
The fix for #16 introduced a `TAGS_URL` setting to specify what the *Tags* title in the sidebar links to, but the docs do not indicate the importance of using this setting. (If `TAGS_URL` isn't set then the *Tags* title just links to the home page, which is confusing.)

This PR adds a line to `README.md`, documenting what `TAGS_URL` does.