### PR TITLE
Add series of images to the sidebar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,7 @@ The footer will display a copyright message using the AUTHOR variable and the ye
 
 Include a series of images in the sidebar.
 
-SIDEBAR_IMAGES = (("/path/to/image1.png"),
-    ("/path/to/image2.png"),)
+SIDEBAR_IMAGES = ["/path/to/image1.png", "/path/to/image2.png"]
 
 ## Live example
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,13 @@ All you have to do, is:
 
 The footer will display a copyright message using the AUTHOR variable and the year of the latest post. If a content license mark is enabled (see above), that will be shown as well.
 
+### Sidebar Images
+
+Include a series of images in the sidebar.
+
+SIDEBAR_IMAGES = (("/path/to/image1.png"),
+    ("/path/to/image2.png"),)
+
 ## Live example
 
 [This is my website](http://dandydev.net)

--- a/templates/includes/sidebar-images.html
+++ b/templates/includes/sidebar-images.html
@@ -1,9 +1,8 @@
 {% if SIDEBAR_IMAGES %}
     <li class="list-group-item">
-    <!--        <h4><i class="fa fa-external-link-square fa-lg"></i><span class="icon-label">{{ SIDEBAR_IMAGE_LABEL }}</span></h4>-->
         <ul class="list-group" id="links">
-        {% for IMAGE in SIDEBAR_IMAGES %}
-            <img width="100%" class="img-thumbnail" src="{{ IMAGE }}"/>
+        {% for image in SIDEBAR_IMAGES %}
+            <img width="100%" class="img-thumbnail" src="{{ image }}"/>
         {% endfor %}
         </ul>
     </li>

--- a/templates/includes/sidebar-images.html
+++ b/templates/includes/sidebar-images.html
@@ -1,0 +1,10 @@
+{% if SIDEBAR_IMAGES %}
+    <li class="list-group-item">
+    <!--        <h4><i class="fa fa-external-link-square fa-lg"></i><span class="icon-label">{{ SIDEBAR_IMAGE_LABEL }}</span></h4>-->
+        <ul class="list-group" id="links">
+        {% for IMAGE in SIDEBAR_IMAGES %}
+            <img width="100%" class="img-thumbnail" src="{{ IMAGE }}"/>
+        {% endfor %}
+        </ul>
+    </li>
+{% endif %}

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -96,6 +96,7 @@
         {% include 'includes/github.html' %}
         {% include 'includes/twitter_timeline.html' %}
         {% include 'includes/links.html' %}
+        {% include 'includes/sidebar-images.html' %}
     </ul>
 </section>
 


### PR DESCRIPTION
Add a series of images to the sidebar.

This is my first real pull request, so helpful tips and "take a hike amateur" are all appreciated. Let me know what I can do better. I cloned the source repo and pulled it down to my machine, made a branch, made my changes on the branch, pushed the branch back to my cloned repo and then created the pull request. Wasn't sure if I should have merged the branch with my master first.

Adds a series of images specified in SIDEBAR_IMAGES to the sidebar. The code is mostly a cut and paste of links.html and aboutme.html. I originally set this up to stick Amazon Web Services certification PNGs in my sidebar. Looks like:

![screenshot_2015-05-20_15-59-33](https://cloud.githubusercontent.com/assets/7488653/7735169/78391022-ff09-11e4-8e8b-9671e9fdfe8f.png)
