### PR TITLE
Check tag_cloud plugin is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ SOCIAL = (('twitter', 'http://twitter.com/DaanDebie'),
 ```
 The first string in each item will be used for both the name as shown in the sidebar, and to determine the [FontAwesome](http://fontawesome.io/icons/)
 icon to show. You can provide an alternative icon string as the third string (as shown in the _stackoverflow_ item).
-* **Tags** will be shown if `DISPLAY_TAGS_ON_SIDEBAR` is set to _True_. Normally, tags are shown as a list.
+* **Tags** will be shown if `DISPLAY_TAGS_ON_SIDEBAR` is set to _True_ and the [tag_cloud](https://github.com/getpelican/pelican-plugins/tree/master/tag_cloud) plugin is enabled. Normally, tags are shown as a list.
 	* Set `DISPLAY_TAGS_INLINE` to _True_, to display the tags inline (ie. as tagcloud)
 	* Set `TAGS_URL` to the relative URL of the tags index page (typically `tags.html`)
 * **Categories** will be shown if `DISPLAY_CATEGORIES_ON_SIDEBAR` is set to _True_

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -55,7 +55,7 @@
             </li>
         {% endif %}
 
-        {% if DISPLAY_TAGS_ON_SIDEBAR %}
+        {% if 'tag_cloud' in PLUGINS and DISPLAY_TAGS_ON_SIDEBAR %}
             {% if DISPLAY_TAGS_INLINE %}
                 {% set tags = tag_cloud | sort(attribute='0') %}
             {% else %}


### PR DESCRIPTION
In version 3.6.0 of Pelican tag_cloud was moved from core to a plugin.
Hence we check the plugin is enabled before displaying the tag cloud.