### PR TITLE
add output_area CSS to IPython notebook template

### DIFF
--- a/templates/includes/liquid_tags_nb_header.html
+++ b/templates/includes/liquid_tags_nb_header.html
@@ -21,8 +21,7 @@ div.output_collapsed{margin:0px;padding:0px;display:-webkit-box;-webkit-box-orie
 div.out_prompt_overlay{height:100%;padding:0px 0.4em;position:absolute;border-radius:4px;}
 div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000000;-moz-box-shadow:inset 0 0 1px #000000;box-shadow:inset 0 0 1px #000000;background:rgba(240, 240, 240, 0.5);}
 div.output_prompt{color:darkred;}
-
-a.anchor-link:link{text-decoration:none;padding:0px 20px;visibility:hidden;}
+div.output_area{padding:0;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
 h1:hover .anchor-link,h2:hover .anchor-link,h3:hover .anchor-link,h4:hover .anchor-link,h5:hover .anchor-link,h6:hover .anchor-link{visibility:visible;}
 /* end stuff for output/input prompts*/
 


### PR DESCRIPTION
The css for `div.output_area` from `_nb_header.html` isn't included in `liquid_tags_nb_header.html`.
## Before the fix an output looks like this:

<img width="721" alt="my_second_pelican_post_-_this__for_now___" src="https://cloud.githubusercontent.com/assets/1147167/9141719/66e53780-3d00-11e5-8d1b-b898a0a06911.png">
## After the fix the same output looks like this:

<img width="728" alt="my_second_pelican_post_-_this__for_now___" src="https://cloud.githubusercontent.com/assets/1147167/9141741/82ec9612-3d00-11e5-9a69-09a2044bfc72.png">
