### PR TITLE
Link MathJax.js in HTTPS

### DIFF
--- a/templates/includes/liquid_tags_nb_header.html
+++ b/templates/includes/liquid_tags_nb_header.html
@@ -135,7 +135,7 @@ div.text_cell_render {
 img.anim_icon{padding:0; border:0; vertical-align:middle; -webkit-box-shadow:none; -box-shadow:none}
 </style>
 
-<script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript"></script>
+<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript"></script>
 <script type="text/javascript">
 init_mathjax = function() {
     if (window.MathJax) {


### PR DESCRIPTION
Avoid an error occurs in HTTPS web sites.
The modification is based on _nb_header.html generated by current "liquid_tags.notebook" https://github.com/getpelican/pelican-plugins/blob/master/liquid_tags/notebook.py .
