### PR TITLE
Adding a template to allow banner for an index page

### DIFF
--- a/templates/index_page.html
+++ b/templates/index_page.html
@@ -1,0 +1,4 @@
+{% extends "page.html" %}
+{% block banner %}
+       {% include 'includes/banner.html' %}
+{% endblock %}


### PR DESCRIPTION
Allow for banner when using a static index page with 

:save_as: index.html
:template: index_page
