### PR TITLE
Fixed position of Google Analytics script and added a property default

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -99,6 +99,9 @@
               title="{{ SITENAME }} {{ category }} ATOM Feed"/>
     {% endif %}
 
+    {# This shall be put before ending the <head> section #}
+    {% include 'includes/ga.html' %}
+
 </head>
 <body>
 
@@ -198,7 +201,6 @@
 {% endif %}
 {% include 'includes/github-js.html' %}
 {% include 'includes/disqus_script.html' %}
-{% include 'includes/ga.html' %}
 {% include 'includes/piwik.html' %}
 
 {% block scripts %}{% endblock %}

--- a/templates/includes/ga.html
+++ b/templates/includes/ga.html
@@ -25,7 +25,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', '{{ GOOGLE_ANALYTICS_UNIVERSAL }}', '{{ GOOGLE_ANALYTICS_UNIVERSAL_PROPERTY }}');
+        ga('create', '{{ GOOGLE_ANALYTICS_UNIVERSAL }}', '{{ GOOGLE_ANALYTICS_UNIVERSAL_PROPERTY|default("auto") }}');
         ga('send', 'pageview');
     </script>
     <!-- End Google Analytics Universal Code -->


### PR DESCRIPTION
Google Analytics wants its script be positioned inside the <head> tag. Moreover, the GOOGLE_ANALYTICS_UNIVERSAL_PROPERTY is by default "auto" as given by the GA configuration page.
