### PR TITLE
Fix navbar-brand combined with text

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -112,7 +112,7 @@
                 <span class="icon-bar"></span>
             </button>
             <a href="{{ SITEURL }}/" class="navbar-brand">
-                {% if SITELOGO %}<img src="{{ SITEURL }}/{{ SITELOGO }}" width="{{ SITELOGO_SIZE }}"/> {% endif %}
+                {% if SITELOGO %}<span><img src="{{ SITEURL }}/{{ SITELOGO }}" width="{{ SITELOGO_SIZE }}"/></span> {% endif %}
                 {% if not HIDE_SITENAME %}{{ SITENAME }}{% endif %}
             </a>
         </div>


### PR DESCRIPTION
Adds a simple `span` tag to the navbar-brand image in order to keep the
navbar text inline with the brand image.
