### PR TITLE
Fix gap between navbar and content showing banner.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -193,9 +193,14 @@
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
 <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/respond.min.js"></script>
 
-{% if BANNER %}
-    <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/bodypadding.js"></script>
+{% if BANNER and BANNER_ALL_PAGES %}
+    <!-- Fix body padding because of banner -->
+    {% include 'includes/bodypadding.html' %}
+{% elif BANNER and not BANNER_ALL_PAGES %}
+    <!-- Include block for fixing body padding because of banner -->
+    {% block bodypadding %}{% endblock %}
 {% endif %}
+
 {% include 'includes/github-js.html' %}
 {% include 'includes/disqus_script.html' %}
 {% include 'includes/ga.html' %}

--- a/templates/includes/bodypadding.html
+++ b/templates/includes/bodypadding.html
@@ -1,0 +1,1 @@
+<script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/bodypadding.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,3 +5,7 @@
 {% block banner %}
 	{% include 'includes/banner.html' %}
 {% endblock %}
+
+{% block bodypadding %}
+	<script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/bodypadding.js"></script>
+{% endblock%}


### PR DESCRIPTION
If a banner is shown on the index page, the bodypadding.js script is included on all pages, removing the gap between all content and the navbar even if no banner is there. This fix includes the script only if the banner is actually visible on the page.
