### PR TITLE
Don't display SITENAME in banner if HIDE_SITENAME is set

### DIFF
--- a/templates/includes/banner.html
+++ b/templates/includes/banner.html
@@ -6,11 +6,15 @@
 
 <div id="banner">
 	<div class="container{% if BOOTSTRAP_FLUID %}-fluid{% endif %}">
+		{% if (not HIDE_SITENAME) or BANNER_SUBTITLE %}
 		<div class="copy">
+			{% if not HIDE_SITENAME %}
 			<h1>{{ SITENAME }}</h1>
+			{% endif %}
 			{% if BANNER_SUBTITLE %}
 				<p class="intro">{{ BANNER_SUBTITLE }}</p>
 			{% endif %}
 		</div>
+		{% endif %}
 	</div>
 </div>


### PR DESCRIPTION
It's probably safe to assume that if people don't want to see `SITENAME` in the title, they wouldn't want to see it in the banner, either. Add an `{% if %}` test so that `SITENAME` is only displayed if `HIDE_SITENAME` isn't set.

In addition, wrap the whole `div` in an `{% if %}` expression such that unless we want to display `SITENAME` or `BANNER_SUBTITLE`, we don't generate the `div` at all. The `div` gets a background from CSS, and would appear as a square blot on a banner that would be assumed to be standing on its own.
