### PR TITLE
Added isso comment elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This theme honors the following standard Pelican settings:
 	* `GOOGLE_ANALYTICS` (classic tracking code)
 	* `GOOGLE_ANALYTICS_UNIVERSAL` and `GOOGLE_ANALYTICS_UNIVERSAL_PROPERTY` (Universal tracking code)
 	* `DISQUS_SITENAME`
+	* `ÌSSO_URL`
 	* `PIWIK_URL`, `PIWIK_SSL_URL` and `PIWIK_SITE_ID`
 
 It uses the `tag_cloud` variable for displaying tags in the sidebar. You can control the amount of tags shown with: `TAG_CLOUD_MAX_ITEMS`

--- a/templates/includes/comments.html
+++ b/templates/includes/comments.html
@@ -38,4 +38,9 @@
         <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 
     </section>
+{% elif ISSO_URL %}
+    <hr/>
+    <script data-isso="{{ ISSO_URL }}"
+            src="{{ ISSO_URL }}/js/embed.min.js"></script>
+    <section id="isso-thread"></section>
 {% endif %}


### PR DESCRIPTION
Isso (http://posativ.org/isso/) is an self-hosted comments server, similar to Disqus.
In pelicanconf.py a setting ISSO_URL has to point to the isso server.

I am using this comment system in my blog (https://niebegeg.net).
