### PR TITLE
Display social on sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This theme honors the following standard Pelican settings:
 	* `DISPLAY_CATEGORIES_ON_MENU`
 	* `MENUITEMS`
 	* `LINKS` (Blogroll will be put in the sidebar instead of the head)
+	* `DISPLAY_SOCIAL_ON_SIDEBAR` (Default is True, enables/disables SOCIAL links on Sidebar)
 * Analytics & Comments
 	* `GOOGLE_ANALYTICS` (classic tracking code)
 	* `GOOGLE_ANALYTICS_UNIVERSAL` and `GOOGLE_ANALYTICS_UNIVERSAL_PROPERTY` (Universal tracking code)

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -2,9 +2,13 @@
     {% set DISPLAY_TAGS_ON_SIDEBAR = True %}
 {% endif %}
 
+{% if DISPLAY_SOCIAL_ON_SIDEBAR is not defined %}
+    {% set DISPLAY_SOCIAL_ON_SIDEBAR = True %}
+{% endif %}
+
 <section class="well well-sm">
     <ul class="list-group list-group-flush">
-        {% if SOCIAL %}
+        {% if SOCIAL and DISPLAY_SOCIAL_ON_SIDEBAR %}
             <li class="list-group-item"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Social</span></h4>
               <ul class="list-group" id="social">
                 {% for s in SOCIAL %}


### PR DESCRIPTION
## Add option in sidebar.html to enable/disable SOCIAL links on sidebar

Configuration option is   
- DISPLAY_SOCIAL_ON_SIDEBAR  ( Default  is True )

The variable can be set to True/False to enable SOCIAL on sidebar.
