### PR TITLE
Prevent space between icon and text from being part of hyperlink

### DIFF
--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -18,7 +18,7 @@
                     {% else %}
                         {% set iconattributes = '"fa fa-' ~ name_sanitized ~ '-square fa-lg"' %}
                     {% endif %}
-                <li class="list-group-item"><a href="{{ s[1] }}"><i class={{ iconattributes }}></i> {{ s[0] }}</a></li>
+                <li class="list-group-item"><i class={{ iconattributes }}></i> <a href="{{ s[1] }}">{{ s[0] }}</a></li>
                 {% endfor %}
               </ul>
             </li>
@@ -103,4 +103,3 @@
         {% include 'includes/sidebar-images.html' %}
     </ul>
 </section>
-


### PR DESCRIPTION
I notice in the social sidebar that the image and text are part of the same hyperlink, causing the space between the image and text to be underlined as part of the hyperlink. This commit ensures that only the text is part of the hyperlink.
